### PR TITLE
Always call the complete method before returning from the query method of the aurora driver

### DIFF
--- a/plugins/drivers/aurora-rds/src/index.ts
+++ b/plugins/drivers/aurora-rds/src/index.ts
@@ -76,7 +76,8 @@ const rdsDriver: DriverBuilder<AuroraRdsParameters, AWS.RDSDataService> = (
         const result = await dataService.executeStatement(queryParameters).promise();
 
         if (result.records === undefined) {
-          return [];
+          subscriber.complete();
+          return;
         }
 
         result.records


### PR DESCRIPTION
Update queries are stuck because subscriber.complete() isn't performed.