### PR TITLE
fix: wrong filename

### DIFF
--- a/packages/data-migration/src/MigrationScript.ts
+++ b/packages/data-migration/src/MigrationScript.ts
@@ -6,11 +6,14 @@ export type ScriptContext = {
   getDriver: <T extends Driver<any, any>>(name: string) => Promise<T>;
   getDriversUsed: () => Array<string>;
   getConfigValue: (key: string) => string;
+  scriptPath: string;
+  directory: string;
 };
 
 export type MigrationExecutor<T> = (context: ScriptContext, log: Logger) => Promise<T>;
 
 export default interface MigrationScript {
+  filename: string;
   description?: string;
   up: MigrationExecutor<void>;
   down?: MigrationExecutor<void>;


### PR DESCRIPTION
Migration scripts have the wrong value for `__dirname` and `__filename`. This resolves the issue.