### PR TITLE
fix(processor): use stage default parameters

### DIFF
--- a/packages/data-migration-cli/src/utils/loadScripts.ts
+++ b/packages/data-migration-cli/src/utils/loadScripts.ts
@@ -53,7 +53,7 @@ export default async function loadScripts(
   );
 
   logger("Creating script context");
-  context = DataMigrationProcessor.createScriptContext(drivers, stageParams, logger);
+  context = DataMigrationProcessor.createScriptContext(drivers, stageParams, logger, stageConfig.defaultParams);
 
   logger("Creating migration tracker");
   const tracker = await DataMigrationProcessor.loadExecutionTracker(stageConfig, logger, () =>

--- a/packages/data-migration/src/methods/CreateScriptContext.ts
+++ b/packages/data-migration/src/methods/CreateScriptContext.ts
@@ -6,6 +6,7 @@ export default function createScriptContext(
   drivers: Map<string, Driver<any, any>>,
   config: { [key: string]: string },
   log: Logger,
+  defaultParams?: Record<string, string>
 ): ScriptContext {
   let driversUsed: Array<string> = [];
   return {
@@ -28,7 +29,7 @@ export default function createScriptContext(
 
       if (driversUsed.indexOf(driverName) === -1) {
         log(`Processing ${driverName} parameters`);
-        result.parameters = await ProcessParams(result.parameters, log);
+        result.parameters = await ProcessParams(result.parameters, log, defaultParams);
         
         driversUsed.push(driverName);
         if (result.init) await result.init();


### PR DESCRIPTION
Passes the current configuration stage's default parameters to the
context so they can be used when running processors